### PR TITLE
Add changes to allow copying modules when using spacewalk-manage-channel-lifecycle

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2219,6 +2219,34 @@ public class ChannelSoftwareHandler extends BaseHandler {
      */
     public Object[] mergePackages(User loggedInUser, String mergeFromLabel,
             String mergeToLabel) {
+        return mergePackages(loggedInUser, mergeFromLabel, mergeToLabel, false);
+    }
+
+    /**
+     * Merge a channel's packages into another channel.
+     * @param loggedInUser The current user
+     * @param mergeFromLabel the label of the channel to pull the packages from
+     * @param mergeToLabel the label of the channel to push packages into
+     * @param alignModules whether to align RHEL >= 8 modular data
+     * @throws CopyModuleMetadataFileFailedException thrown on error copying modules.yaml file
+     * @return A list of packages that were merged.
+     *
+     * @xmlrpc.doc Merges all packages from one channel into another
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "mergeFromLabel", "the label of the
+     *          channel to pull packages from")
+     * @xmlrpc.param #param_desc("string", "mergeToLabel", "the label to push the
+     *              packages into")
+     * @xmlrpc.param #param_desc("boolean", "alignModules", "align modular data of the target channel
+     *              to the source channel (RHEL8 and higher)")
+     * @xmlrpc.returntype
+     *      #array_begin()
+     *          $PackageSerializer
+     *      #array_end()
+     */
+    public Object[] mergePackages(User loggedInUser, String mergeFromLabel,
+            String mergeToLabel, boolean alignModules)
+        throws CopyModuleMetadataFileFailedException {
 
         Channel mergeFrom = lookupChannelByLabel(loggedInUser, mergeFromLabel);
         Channel mergeTo = lookupChannelByLabel(loggedInUser, mergeToLabel);
@@ -2241,6 +2269,10 @@ public class ChannelSoftwareHandler extends BaseHandler {
         mergeTo.getPackages().addAll(differentPackages);
         ChannelFactory.save(mergeTo);
         ChannelManager.refreshWithNewestPackages(mergeTo, "java::mergePackages");
+
+        if (alignModules) {
+            ChannelManager.cloneChannelModulesFile(mergeFrom, mergeTo);
+        }
 
         List<Long> cids = new ArrayList<Long>();
         cids.add(mergeTo.getId());

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -231,7 +231,8 @@ def merge_channels(source_label, dest_label):
             try:
                 errata = client.channel.software.mergeErrata(session,
                                                              source_label,
-                                                             dest_label)
+                                                             dest_label,
+                                                             True)
 
                 logging.info('Added %i errata' % len(errata))
             except xmlrpclib.Fault, e:

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -210,7 +210,8 @@ def merge_channels(source_label, dest_label):
         try:
             packages = client.channel.software.mergePackages(session,
                                                              source_label,
-                                                             dest_label)
+                                                             dest_label,
+                                                             True)
 
             logging.info('Added %i packages' % len(packages))
         except xmlrpclib.Fault, e:

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -210,7 +210,8 @@ def merge_channels(source_label, dest_label):
         try:
             packages = client.channel.software.mergePackages(session,
                                                              source_label,
-                                                             dest_label)
+                                                             dest_label,
+                                                             True)
 
             logging.info('Added %i packages' % len(packages))
         except xmlrpclib.Fault, e:
@@ -231,8 +232,7 @@ def merge_channels(source_label, dest_label):
             try:
                 errata = client.channel.software.mergeErrata(session,
                                                              source_label,
-                                                             dest_label,
-                                                             True)
+                                                             dest_label)
 
                 logging.info('Added %i errata' % len(errata))
             except xmlrpclib.Fault, e:


### PR DESCRIPTION
I've made some changes to also handle copying modules.yaml when using `spacewalk-manage-channel-lifecycle` to refresh channels on a regular basis.

Cherry picked some changes from https://github.com/uyuni-project/uyuni/pull/2745 ( https://github.com/uyuni-project/uyuni/pull/2745/commits/ce867fccc56e658f8823bda04112768dacaf5fc9) and adapted it to this version of Spacewalk.

